### PR TITLE
Updating to metabase version 0.33.6

### DIFF
--- a/R/r_metabase.R
+++ b/R/r_metabase.R
@@ -87,7 +87,7 @@ mb_url <- function(base_url, path) {
 }
 
 mb_req_error_processor <- function(req) {
-  if (req$status_code != 200) {
+  if (req$status_code < 200 || req$status_code >= 300) {
     stop(paste("Request failed:", req$url, " returned: ", req$status_code))
   }
 }

--- a/R/r_metabase.R
+++ b/R/r_metabase.R
@@ -21,17 +21,15 @@ metabase_init <- function (base_url, username, password = NULL) {
     username = username,
     password = password
   )
-  credsAsJSON <- jsonlite::toJSON(creds, auto_unbox=TRUE)
+  
+  base_url<-sub("/$","",base_url) #Remove final slash if present metabase can't handle //
 
-  req <- httr::POST(mb_url(base_url, '/api/session'),
-                    httr::add_headers(
-                      "Content-Type" = "application/json"
-                    ),
-                    body = credsAsJSON
-  )
+  req <- httr::POST(mb_url(base_url, '/api/session'),body = creds,encode="json")
 
   if (req$status_code >= 200 && req$status_code < 300) {
-    jsonAuthResponse <- httr::content(req, "text")
+    jsonAuthResponse <- httr::content(req, "text", encoding="UTF-8")
+    #cat(jsonAuthResponse)
+    #return(list(req=req,resp=jsonAuthResponse))
     mb_session_token <- toString(jsonlite::fromJSON(jsonAuthResponse))
 
     # make sure session is legit
@@ -62,20 +60,21 @@ metabase_init <- function (base_url, username, password = NULL) {
 #' @export
 metabase_fetch_question <- function(metabase_session, id, params = list()) {
   mb_verify_session(metabase_session)
+  
+  #Example: 'parameters=[{"type":"category","target":["variable",["template-tag","project_id"]],"value":"2559"}]'
 
-  data<-list(
-    "ignore_cache" = FALSE,
-    "parameters"   = params
-  )
-  dataAsJSON <- jsonlite::toJSON(data, auto_unbox=TRUE)
+  param_names<-names(params)
+  param_vals<-unlist(params, use.names=FALSE)
+  data=list()
+  for (i in 1:length(param_names)) {
+    data[[i]]=list("type"="category","target"=list("variable",list("template-tag",param_names[i])),"value"=param_vals[i])
+  }
+  data<-list("parameters"=jsonlite::toJSON(data, auto_unbox = TRUE))
 
   query_url_part = paste0('/api/card/', id, '/query/json', "")
   req <- httr::POST(mb_url(metabase_session$base_url, query_url_part),
-                    httr::add_headers(
-                      "Content-Type" = "application/json",
-                      "X-Metabase-Session" = metabase_session$token
-                    )
-  );
+                    httr::add_headers("X-Metabase-Session" = metabase_session$token, "Content-Type"="application/x-www-form-urlencoded"),
+                    body=data, encode="form")#, httr::verbose())
   mb_req_error_processor(req)
 
   questionJSON <- httr::content(req,"text")

--- a/R/r_metabase.R
+++ b/R/r_metabase.R
@@ -58,7 +58,7 @@ metabase_init <- function (base_url, username, password = NULL) {
 #' metabase_fetch_question(sess, 242, list(customer_id = 4))
 #'
 #' @export
-metabase_fetch_question <- function(metabase_session, id, params = list()) {
+metabase_fetch_question <- function(metabase_session, id, params = list(), tmpdir=FALSE) {
   mb_verify_session(metabase_session)
   
   #Example: 'parameters=[{"type":"category","target":["variable",["template-tag","project_id"]],"value":"2559"}]'
@@ -78,6 +78,13 @@ metabase_fetch_question <- function(metabase_session, id, params = list()) {
   mb_req_error_processor(req)
 
   questionJSON <- httr::content(req,"text")
+  if (tmpdir!=FALSE){
+    tfile<-tempfile(tmpdir=tmpdir,fileext=".json")
+    print(paste0("Saving to ",tfile))
+    fileConn<-file(tfile)
+    writeLines(questionJSON, fileConn)
+    close(fileConn)
+  }
   questionData <- jsonlite::fromJSON(questionJSON)
 }
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# metabaser
+
+## Summary
+
+A metabase driver for R. Easily access data from your Metabase questions for analysis in R.
+
+This is an update to a previous package by apinstein to work with metabase version 0.33.6 (latest avilable as of January 1, 2020).
+
+## Installation
+1. Ensure the necessary packages are available within R
+```
+install.packages(c("jsonlite","httr","devtools"))
+```
+2. Install this library
+```
+library(devtools)
+install_github("meedan/metabaser")
+```
+
+## First example
+1. Load the package
+```
+library(metabaser)
+```
+2. Establish a metabase session.
+```
+mb_session <- metabase_init("https://your-metabase-site.com", username="user@your-metabase-site.com", password="your-metabase-password")
+```
+If you use RStudio and ommit the password argument, you will be prompted for a password.
+3. Execute a query. Here is a simple question without any parameters. 
+The "id" of the question is clearly visible in the querystring when using metabase in your browser.
+```
+dfMyData <- metabase_fetch_question(mb_session, id=42)
+```
+
+If you have parameters to your question, these should be added in the ``params`` argument as a list
+```
+dfMyData <- metabase_fetch_question(mb_session, id=42, params = list("answer"=project_id) )
+```
+
+## Contact
+
+Further information is available from Scott Hale. Meedan team members can 
+contact Scott via Slack and others can reach out to Scott via comments/issues
+on this repository or via [direct message on Twitter](https://twitter.com/computermacgyve)


### PR DESCRIPTION
It appears that the current version of metabase (0.33.6) handles parameters for cards/questions differently. 

The new format is described at https://discourse.metabase.com/t/metabase-api-troubles-using-api-card-with-parameters/2463/5 . 

for a question with parameters, the request is a POST with application/x-www-form-urlencoded encoding and a single "parameters" variable that contains the JSON payload. For example,

```
parameters=[{"type":"category","target":["variable",["template-tag","my_var_name"]],"value":"the_value_here"}]
```
specifies  the parameter "my_var_name" has "the_value_here" when executing the card/question. I've left the input to ```metabase_fetch_question``` unchanged. The function now remaps key->value lists into the needed JSON structure. It is working for me, but I have not thoroughly tested all permutations (e.g., I've only used integer parameters thus far)
